### PR TITLE
Update permissions during COPY in Dockerfiles

### DIFF
--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -1,8 +1,8 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/hello.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/hello.war
 
 EXPOSE 9080

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -1,8 +1,8 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/hello.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/hello.war
 
 EXPOSE 9080


### PR DESCRIPTION
Since OL images now run as non-root, we have to make sure that all the artifacts being copied into the image have the correct permissions to be read and executed by user 1001 or group 0.