### PR TITLE
Added set error flag to report intermediate test failure

### DIFF
--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 ##############################################################################
 ##
@@ -8,32 +9,24 @@
 
 # Deploy
 
-printf "\nmvn -q clean package\n"
 mvn -q clean package
 
-printf "\nkubectl apply -f ../scripts/hello.yaml\n"
 kubectl apply -f ../scripts/hello.yaml
 
-printf "\nsleep 120\n"
 sleep 120
 
-printf "\nkubectl get pods\n"
 kubectl get pods
 
-printf "\nminikube ip\n"
 echo `minikube ip`
 
-printf "\ncurl http://`minikube ip`:31000/hello\n"
 curl http://`minikube ip`:31000/hello
 
 # Run tests
 
-printf "\nmvn verify -Ddockerfile.skip=true -Dcluster.ip=`minikube ip` -Dport=31000\n"
 mvn verify -Ddockerfile.skip=true -Dcluster.ip=`minikube ip` -Dport=31000
 
 # Print logs
 
 POD_NAME=$(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep hello)
 
-printf "\nkubectl logs $POD_NAME hello-container\n"
 kubectl logs $POD_NAME


### PR DESCRIPTION
- fixed the test script to fail at intermediate steps with the `set -e` bash script flag
  - reference info for the `set -euxo pipefail` flag : https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
- addressed issues reported in https://github.com/openliberty/guides-common/issues/223