### PR TITLE
Fix the unclear minikube instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -514,7 +514,7 @@ kubectl delete -f install/kubernetes/istio-demo.yaml
 ```
 
 ****
-[system]#*{linux} | {mac}*#
+[system]#*{mac}*#
 
 [role=command]
 ```
@@ -526,11 +526,34 @@ for i in install/kubernetes/helm/istio-init/files/crd*yaml; do kubectl delete -f
 ```
 FOR %i in (install\kubernetes\helm\istio-init\files\crd*yaml) DO kubectl delete -f %i
 ```
-****
 
+[system]#*{linux}*#
 
 [role=command]
-include::{common-includes}/kube-minikube-teardown.adoc[]
+```
+for i in install/kubernetes/helm/istio-init/files/crd*yaml; do kubectl delete -f $i; done
+```
+
+Perform the following steps to return your environment to a clean state.
+
+. Point the Docker daemon back to your local machine:
++
+```
+eval $(minikube docker-env -u)
+```
+
+. Stop your Minikube cluster:
++
+```
+minikube stop
+```
+
+. Delete your cluster:
++
+```
+minikube delete
+```
+****
 
 // =================================================================================================
 // finish

--- a/README.adoc
+++ b/README.adoc
@@ -538,19 +538,16 @@ Perform the following steps to return your environment to a clean state.
 
 . Point the Docker daemon back to your local machine:
 +
+[role=command]
 ```
 eval $(minikube docker-env -u)
 ```
 
-. Stop your Minikube cluster:
+. Stop and delete your Minikube cluster:
 +
+[role=command]
 ```
 minikube stop
-```
-
-. Delete your cluster:
-+
-```
 minikube delete
 ```
 ****


### PR DESCRIPTION
It is so confusion about the instructions at the tearing down section: 
`LINUX | MAC`,  `WINDOWS`, `WINDOWS | MAC`, `LINUX`

This PR cleaned it up to be  `MAC`, `WINDOWS`, `LINUX`